### PR TITLE
Turn on assertions by default, add opt-out option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Build options
 
 The standard `postgresql` formula in Homebrew is missing a number of build options and also has a number of build options that I find useless.  These formulae enable all `configure` options that OS X can support, but also remove a number of Homebrew-level build options, to reduce complexity.  I have also dropped supported for legacy OS X concerns, such as 32-bit Intel and PowerPC and really old OS X releases.  Mainly because I can't test that anymore, YMMV.
 
+Assertions are enabled by default: to disable them, pass `--disable-assertions` to the install command.
+
 postgresql-common cluster manager
 ---------------------------------
 

--- a/postgresql-8.3.rb
+++ b/postgresql-8.3.rb
@@ -6,6 +6,8 @@ class Postgresql83 < Formula
   sha1 'e479f3eced32a14ada66082de7c8b33f77e2588b'
   head 'http://git.postgresql.org/git/postgresql.git', :branch => 'REL8_3_STABLE'
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -33,6 +35,8 @@ class Postgresql83 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    args << "--enable-cassert" unless build.include? "disable-assertions"
 
     system "./configure", *args
     system "make install"

--- a/postgresql-8.4.rb
+++ b/postgresql-8.4.rb
@@ -6,6 +6,8 @@ class Postgresql84 < Formula
   sha256 '5c1d56ce77448706d9dd03b2896af19d9ab1b9b8dcdb96c39707c74675ca3826'
   head 'http://git.postgresql.org/git/postgresql.git', :branch => 'REL8_4_STABLE'
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -34,6 +36,8 @@ class Postgresql84 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    args << "--enable-cassert" unless build.include? "disable-assertions"
 
     system "./configure", *args
     system "make install"

--- a/postgresql-9.0.rb
+++ b/postgresql-9.0.rb
@@ -13,6 +13,8 @@ class Postgresql90 < Formula
     depends_on 'petere/sgml/openjade' => :build
   end
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -41,6 +43,8 @@ class Postgresql90 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    args << "--enable-cassert" unless build.include? "disable-assertions"
 
     system "./configure", *args
     system "make install-world"

--- a/postgresql-9.1.rb
+++ b/postgresql-9.1.rb
@@ -13,6 +13,8 @@ class Postgresql91 < Formula
     depends_on 'petere/sgml/openjade' => :build
   end
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -41,6 +43,8 @@ class Postgresql91 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    args << "--enable-cassert" unless build.include? "disable-assertions"
 
     system "./configure", *args
     system "make install-world"

--- a/postgresql-9.2.rb
+++ b/postgresql-9.2.rb
@@ -13,6 +13,8 @@ class Postgresql92 < Formula
     depends_on 'petere/sgml/openjade' => :build
   end
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -41,6 +43,8 @@ class Postgresql92 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    args << "--enable-cassert" unless build.include? "disable-assertions"
 
     system "./configure", *args
     system "make install-world"

--- a/postgresql-9.3.rb
+++ b/postgresql-9.3.rb
@@ -13,6 +13,8 @@ class Postgresql93 < Formula
     depends_on 'petere/sgml/openjade' => :build
   end
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -41,6 +43,8 @@ class Postgresql93 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    args << "--enable-cassert" unless build.include? "disable-assertions"
 
     system "./configure", *args
     system "make install-world"

--- a/postgresql-9.4.rb
+++ b/postgresql-9.4.rb
@@ -13,6 +13,8 @@ class Postgresql94 < Formula
     depends_on 'petere/sgml/openjade' => :build
   end
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -38,6 +40,7 @@ class Postgresql94 < Formula
             "--with-python",
             "--with-tcl"]
 
+    args << "--enable-cassert" unless build.include? "disable-assertions"
     args << "--with-extra-version=+git" if build.head?
 
     system "./configure", *args

--- a/postgresql-9.5.rb
+++ b/postgresql-9.5.rb
@@ -11,6 +11,8 @@ class Postgresql95 < Formula
     depends_on 'petere/sgml/openjade' => :build
   end
 
+  option 'disable-assertions', 'Speeds up PostgreSQL but skips tests valuable during development'
+
   keg_only 'The different provided versions of PostgreSQL conflict with each other.'
 
   env :std
@@ -36,6 +38,7 @@ class Postgresql95 < Formula
             "--with-python",
             "--with-tcl"]
 
+    args << "--enable-cassert" unless build.include? "disable-assertions"
     args << "--with-extra-version=+git" if build.head?
 
     system "./configure", *args


### PR DESCRIPTION
This package seems aimed at PostgreSQL developers. As assertions are most useful during development, it seems reasonable to have them on by default.