### PR TITLE
Enable warnings during builds

### DIFF
--- a/postgresql-8.3.rb
+++ b/postgresql-8.3.rb
@@ -27,6 +27,8 @@ class Postgresql83 < Formula
   patch :DATA
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--mandir=#{man}",
             "--enable-thread-safety",

--- a/postgresql-8.4.rb
+++ b/postgresql-8.4.rb
@@ -33,6 +33,8 @@ class Postgresql84 < Formula
   patch :DATA
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",

--- a/postgresql-9.0.rb
+++ b/postgresql-9.0.rb
@@ -34,6 +34,8 @@ class Postgresql90 < Formula
   patch :DATA
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",

--- a/postgresql-9.1.rb
+++ b/postgresql-9.1.rb
@@ -34,6 +34,8 @@ class Postgresql91 < Formula
   patch :DATA
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",

--- a/postgresql-9.2.rb
+++ b/postgresql-9.2.rb
@@ -34,6 +34,8 @@ class Postgresql92 < Formula
   patch :DATA
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",

--- a/postgresql-9.3.rb
+++ b/postgresql-9.3.rb
@@ -34,6 +34,8 @@ class Postgresql93 < Formula
   patch :DATA
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",

--- a/postgresql-9.4.rb
+++ b/postgresql-9.4.rb
@@ -31,6 +31,8 @@ class Postgresql94 < Formula
   depends_on "homebrew/dupes/tcl-tk"
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",

--- a/postgresql-9.5.rb
+++ b/postgresql-9.5.rb
@@ -26,6 +26,8 @@ class Postgresql95 < Formula
   depends_on "homebrew/dupes/tcl-tk"
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",

--- a/postgresql-9.6.rb
+++ b/postgresql-9.6.rb
@@ -23,6 +23,8 @@ class Postgresql96 < Formula
   depends_on "homebrew/dupes/tcl-tk"
 
   def install
+    ENV.enable_warnings
+
     args = ["--prefix=#{prefix}",
             "--enable-dtrace",
             "--enable-nls",


### PR DESCRIPTION
Somewhat unexpectedly, Homebrew disables warnings on all builds unless told otherwise. See Homebrew/homebrew#9728.

This might be all well and good for the wild west of Homebrew, but within this specific package it would be great to have them on by default. Since (I think) PostgreSQL/PGXS passes the `CFLAGS` used for its compilation down to compiled extensions, it's critical that the `-w` flag inserted by Homebrew not appear.

For instance, checking the output of `pg_config` in Ubuntu (with a package-provided PostgreSQL) shows:

```
CFLAGS = -O2 -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard
```

If PostgreSQL adds all those warning flags, it is clearly not its intent to have them all negated by a `-w` added by Homebrew.

Motivation: I was building extensions for around 45 days without realizing warnings were being suppressed. Figured out the problem when inspecting Travis output one day. Turned on "warnings are errors" after that and fixed my own PostgreSQL installs, but wanted others to know about this behavior.