### PR TITLE
Switch back to superenv

### DIFF
--- a/postgresql-8.3.rb
+++ b/postgresql-8.3.rb
@@ -14,8 +14,6 @@ class Postgresql83 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "homebrew/dupes/openldap"
   depends_on "openssl"
   depends_on "ossp-uuid"
@@ -41,6 +39,15 @@ class Postgresql83 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
 

--- a/postgresql-8.4.rb
+++ b/postgresql-8.4.rb
@@ -20,8 +20,6 @@ class Postgresql84 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
   depends_on "openssl"
@@ -48,6 +46,15 @@ class Postgresql84 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
 

--- a/postgresql-9.0.rb
+++ b/postgresql-9.0.rb
@@ -22,8 +22,6 @@ class Postgresql90 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
   depends_on "openssl"
@@ -50,6 +48,15 @@ class Postgresql90 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
 

--- a/postgresql-9.1.rb
+++ b/postgresql-9.1.rb
@@ -22,8 +22,6 @@ class Postgresql91 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
   depends_on "openssl"
@@ -50,6 +48,15 @@ class Postgresql91 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
 

--- a/postgresql-9.2.rb
+++ b/postgresql-9.2.rb
@@ -22,8 +22,6 @@ class Postgresql92 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
   depends_on "openssl"
@@ -50,6 +48,15 @@ class Postgresql92 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
 

--- a/postgresql-9.3.rb
+++ b/postgresql-9.3.rb
@@ -22,8 +22,6 @@ class Postgresql93 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
   depends_on "openssl"
@@ -50,6 +48,15 @@ class Postgresql93 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
 

--- a/postgresql-9.4.rb
+++ b/postgresql-9.4.rb
@@ -22,8 +22,6 @@ class Postgresql94 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "e2fsprogs"
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
@@ -46,6 +44,15 @@ class Postgresql94 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
     args << "--with-extra-version=+git" if build.head?

--- a/postgresql-9.5.rb
+++ b/postgresql-9.5.rb
@@ -17,8 +17,6 @@ class Postgresql95 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "e2fsprogs"
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
@@ -41,6 +39,15 @@ class Postgresql95 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
     args << "--with-extra-version=+git" if build.head?

--- a/postgresql-9.6.rb
+++ b/postgresql-9.6.rb
@@ -14,8 +14,6 @@ class Postgresql96 < Formula
 
   keg_only "The different provided versions of PostgreSQL conflict with each other."
 
-  env :std
-
   depends_on "e2fsprogs"
   depends_on "gettext"
   depends_on "homebrew/dupes/openldap"
@@ -38,6 +36,15 @@ class Postgresql96 < Formula
             "--with-perl",
             "--with-python",
             "--with-tcl"]
+
+    # Add include and library directories of dependencies, so that
+    # they can be used for compiling extensions.  Superenv does this
+    # when compiling this package, but won't record it for pg_config.
+    deps = %w[gettext openldap openssl readline tcl-tk]
+    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
+    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    args << "--with-includes=#{with_includes}"
+    args << "--with-libraries=#{with_libraries}"
 
     args << "--enable-cassert" if build.include? "enable-cassert"
     args << "--with-extra-version=+git" if build.head?


### PR DESCRIPTION
The standard environment turns off warnings with `-w`, which propagates
to PGXS builds.  We could override, but it seems more future-proof to
switch to the superenv.

closes #17