### PR TITLE
Fix assert-enabled builds

### DIFF
--- a/postgresql-10.rb
+++ b/postgresql-10.rb
@@ -50,7 +50,7 @@ class Postgresql10 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
     args << "--with-extra-version=+git" if build.head?
 
     system "./configure", *args

--- a/postgresql-8.3.rb
+++ b/postgresql-8.3.rb
@@ -47,7 +47,7 @@ class Postgresql83 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
 
     system "./configure", *args
     system "make", "install"

--- a/postgresql-8.4.rb
+++ b/postgresql-8.4.rb
@@ -54,7 +54,7 @@ class Postgresql84 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
 
     system "./configure", *args
     system "make", "install"

--- a/postgresql-9.0.rb
+++ b/postgresql-9.0.rb
@@ -56,7 +56,7 @@ class Postgresql90 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
 
     system "./configure", *args
     system "make", "install-world"

--- a/postgresql-9.1.rb
+++ b/postgresql-9.1.rb
@@ -57,7 +57,7 @@ class Postgresql91 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
 
     system "./configure", *args
     system "make", "install-world"

--- a/postgresql-9.2.rb
+++ b/postgresql-9.2.rb
@@ -57,7 +57,7 @@ class Postgresql92 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
 
     system "./configure", *args
     system "make", "install-world"

--- a/postgresql-9.3.rb
+++ b/postgresql-9.3.rb
@@ -57,7 +57,7 @@ class Postgresql93 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
 
     system "./configure", *args
     system "make", "install-world"

--- a/postgresql-9.4.rb
+++ b/postgresql-9.4.rb
@@ -53,7 +53,7 @@ class Postgresql94 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
     args << "--with-extra-version=+git" if build.head?
 
     system "./configure", *args

--- a/postgresql-9.5.rb
+++ b/postgresql-9.5.rb
@@ -53,7 +53,7 @@ class Postgresql95 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
     args << "--with-extra-version=+git" if build.head?
 
     system "./configure", *args

--- a/postgresql-9.6.rb
+++ b/postgresql-9.6.rb
@@ -53,7 +53,7 @@ class Postgresql96 < Formula
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 
-    args << "--enable-cassert" if build.include? "enable-cassert"
+    args << "--enable-cassert" if build.include? "with-cassert"
     args << "--with-extra-version=+git" if build.head?
 
     system "./configure", *args


### PR DESCRIPTION
The brew flag was changed to `with-cassert`, but the actual conditional was left untouched. Since the deprecated option `enable-cassert` gets remapped to `with-cassert`, it's now impossible to build assert-enabled PostgreSQL versions.

This change simply fixes the conditional in all version files.

Confirmed by checking the output of old `with-cassert` or `enable-cassert` builds, neither of which actually built an assert-enabled PostgreSQL. After this change, assert-enabled builds result. 
