### PR TITLE
Switch from dupes for openldap and tcl-tk

### DIFF
--- a/postgresql@10.rb
+++ b/postgresql@10.rb
@@ -20,11 +20,11 @@ class PostgresqlAT10 < Formula
 
   depends_on "e2fsprogs"
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "icu4c"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   def install
     args = %W[

--- a/postgresql@8.3.rb
+++ b/postgresql@8.3.rb
@@ -10,11 +10,11 @@ class PostgresqlAT83 < Formula
   deprecated_option "enable-cassert" => "with-cassert"
   option "with-cassert", "Enable assertion checks (for debugging)"
 
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "ossp-uuid"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   # Fix PL/Python build: https://github.com/mxcl/homebrew/issues/11162
   # Fix uuid-ossp build issues: https://archives.postgresql.org/pgsql-general/2012-07/msg00654.php

--- a/postgresql@8.4.rb
+++ b/postgresql@8.4.rb
@@ -17,11 +17,11 @@ class PostgresqlAT84 < Formula
   option "with-cassert", "Enable assertion checks (for debugging)"
 
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "ossp-uuid"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   # Fix uuid-ossp build issues: https://archives.postgresql.org/pgsql-general/2012-07/msg00654.php
   patch :DATA

--- a/postgresql@9.0.rb
+++ b/postgresql@9.0.rb
@@ -19,11 +19,11 @@ class PostgresqlAT90 < Formula
   option "with-cassert", "Enable assertion checks (for debugging)"
 
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "ossp-uuid"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   # Fix uuid-ossp build issues: https://archives.postgresql.org/pgsql-general/2012-07/msg00654.php
   patch :DATA

--- a/postgresql@9.1.rb
+++ b/postgresql@9.1.rb
@@ -20,11 +20,11 @@ class PostgresqlAT91 < Formula
   option "with-cassert", "Enable assertion checks (for debugging)"
 
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "ossp-uuid"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   # Fix uuid-ossp build issues: https://archives.postgresql.org/pgsql-general/2012-07/msg00654.php
   patch :DATA

--- a/postgresql@9.2.rb
+++ b/postgresql@9.2.rb
@@ -20,11 +20,11 @@ class PostgresqlAT92 < Formula
   option "with-cassert", "Enable assertion checks (for debugging)"
 
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "ossp-uuid"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   # Fix uuid-ossp build issues: https://archives.postgresql.org/pgsql-general/2012-07/msg00654.php
   patch :DATA

--- a/postgresql@9.3.rb
+++ b/postgresql@9.3.rb
@@ -20,11 +20,11 @@ class PostgresqlAT93 < Formula
   option "with-cassert", "Enable assertion checks (for debugging)"
 
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "ossp-uuid"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   # Fix uuid-ossp build issues: https://archives.postgresql.org/pgsql-general/2012-07/msg00654.php
   patch :DATA

--- a/postgresql@9.4.rb
+++ b/postgresql@9.4.rb
@@ -21,10 +21,10 @@ class PostgresqlAT94 < Formula
 
   depends_on "e2fsprogs"
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   def install
     args = %W[

--- a/postgresql@9.5.rb
+++ b/postgresql@9.5.rb
@@ -21,10 +21,10 @@ class PostgresqlAT95 < Formula
 
   depends_on "e2fsprogs"
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   def install
     args = %W[

--- a/postgresql@9.6.rb
+++ b/postgresql@9.6.rb
@@ -21,10 +21,10 @@ class PostgresqlAT96 < Formula
 
   depends_on "e2fsprogs"
   depends_on "gettext"
-  depends_on "homebrew/dupes/openldap"
+  depends_on "openldap"
   depends_on "openssl"
   depends_on "readline"
-  depends_on "homebrew/dupes/tcl-tk"
+  depends_on "tcl-tk"
 
   def install
     args = %W[


### PR DESCRIPTION
This should prevent the deprecation warnings on install.

Closes #32 