### PR TITLE
Fix failure in building of perl integration source for 9.2 on macOS

### DIFF
--- a/postgresql@9.2.rb
+++ b/postgresql@9.2.rb
@@ -53,9 +53,16 @@ class PostgresqlAT92 < Formula
     # Add include and library directories of dependencies, so that
     # they can be used for compiling extensions.  Superenv does this
     # when compiling this package, but won't record it for pg_config.
-    deps = %w[gettext openldap openssl readline tcl-tk]
-    with_includes = deps.map { |f| Formula[f].opt_include }.join(":")
-    with_libraries = deps.map { |f| Formula[f].opt_lib }.join(":")
+    brew_deps = %w[gettext openldap openssl readline tcl-tk]
+
+    sys_deps_includes = %W[
+      #{MacOS.sdk_path}/System/Library/Perl/5.18/darwin-thread-multi-2level/CORE
+    ]
+    brew_deps_includes = brew_deps.map { |f| Formula[f].opt_include }
+    deps_includes = sys_deps_includes + brew_deps_includes
+
+    with_includes = deps_includes.join(":")
+    with_libraries = brew_deps.map { |f| Formula[f].opt_lib }.join(":")
     args << "--with-includes=#{with_includes}"
     args << "--with-libraries=#{with_libraries}"
 


### PR DESCRIPTION
Building the previous formula for postgresql@9.2 led to the following error in the make step:

    In file included from plperl.c:49:
    ./plperl.h:53:10: fatal error: 'EXTERN.h' file not found
    #include "EXTERN.h"
             ^~~~~~~~~~

As of XCode 10(?), system headers (which includes the headers for the system version of perl) have been removed from the base macOS system and now only live in the macOS SDK, which must be included explicitly for the build process to find the system perl headers that were previously expected to already be globally available.

See these links for more info:
* https://apple.stackexchange.com/questions/337940/
* https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035623

I'm not sure if this PR is the 'right' way to solve this issue, but it at least made the compilation work for me on macOS 10.14.6. I can port this across to the other formulas as well if you want, it will just involve some more time for me to test which formulas need it and which ones don't.

This seems to be the same kind of issue as raised by #50 and #44 - users on those issues fixed the problem by making perl a brew dependency of the formula, or by installing the temporary workaround `macOS_SDK_headers_for_macOS_10.14.pkg` supplied by Apple that puts all the headers back in the system root (this is apparently not available on 10.15 Catalina though). The fix in this PR at least avoids the user needing to make any changes for the formula to compile.

Longer-term though, [Apple will be removing scripting languages like Perl from the base macOS system](https://developer.apple.com/documentation/macos_release_notes/macos_catalina_10_15_release_notes#3318257), so it may be better to add a homebrew dependency on perl instead? Like I said, not sure what the right way forward is, but wanted to at least share this fix as a possible solution.