### PR TITLE
Fix deprecated devel blocks warning in formulae

### DIFF
--- a/postgresql@13.rb
+++ b/postgresql@13.rb
@@ -1,7 +1,8 @@
 class PostgresqlAT13 < Formula
   desc "Relational database management system"
   homepage "https://www.postgresql.org/"
-  devel do
+
+  head do
     version = "13beta1"
     version version
     url "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"

--- a/postgresql@8.4.rb
+++ b/postgresql@8.4.rb
@@ -5,7 +5,7 @@ class PostgresqlAT84 < Formula
   sha256 "5c1d56ce77448706d9dd03b2896af19d9ab1b9b8dcdb96c39707c74675ca3826"
   head "https://git.postgresql.org/git/postgresql.git", :branch => "REL8_4_STABLE"
 
-  devel do
+  head do
     url "https://github.com/credativ/postgresql-lts/releases/download/REL8_4_22LTS6/postgresql-8.4.22lts6.tar.bz2"
     version "8.4.22lts6"
     sha256 "cf6c248e91df6d6aa5d0985f0c2aa4a576215faaf038c85bbdd182552a4bf3c9"


### PR DESCRIPTION
Searching for `petere/postgresql` kept showing depreciation warning. This PR fixes those warnings.


```shell
> brew search petere/postgresql
Warning: Calling 'devel' blocks in formulae is deprecated! Use 'head' blocks or @-versioned formulae instead.
Please report this issue to the petere/postgresql tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/petere/homebrew-postgresql/postgresql@13.rb:4

Warning: Calling 'devel' blocks in formulae is deprecated! Use 'head' blocks or @-versioned formulae instead.
Please report this issue to the petere/postgresql tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/petere/homebrew-postgresql/postgresql@8.4.rb:8

==> Formulae
petere/postgresql/postgresql-common ✔          petere/postgresql/postgresql@14                petere/postgresql/postgresql@9.2
petere/postgresql/postgresql@10                petere/postgresql/postgresql@8.3               petere/postgresql/postgresql@9.3
petere/postgresql/postgresql@11                petere/postgresql/postgresql@8.4               petere/postgresql/postgresql@9.4
petere/postgresql/postgresql@12                petere/postgresql/postgresql@9.0               petere/postgresql/postgresql@9.5
petere/postgresql/postgresql@13                petere/postgresql/postgresql@9.1               petere/postgresql/postgresql@9.6
```