### PR TITLE
Update postgresql@14.rb openssl to v3

### DIFF
--- a/postgresql@14.rb
+++ b/postgresql@14.rb
@@ -23,10 +23,10 @@ class PostgresqlAT14 < Formula
   depends_on "pkg-config" => :build
 
   depends_on "gettext"
-  depends_on "icu4c"
+  depends_on "icu4c@76"
   depends_on "lz4"
   depends_on "openldap"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "python@3"
   depends_on "readline"
   depends_on "tcl-tk"


### PR DESCRIPTION
Hello @petere! 

I'm not sure about how to best contribute here, but I ran into Issue #67, trying to install pg 14 on my computer just now. I started digging into things and found that another formula for installing pg 14 points to a new version of openssl.

From that I [added a comment](https://github.com/petere/homebrew-postgresql/issues/67#issuecomment-2708145000) to #67 wondering if this is just a dependency that can be updated to the new version.

I decided to try this install on my computer - so I forked the repo, made this update, and installed with home-brew. It appears that the install worked correctly, and I was then able to create and run a cluster.

I thought I'd open this PR up as a proposal. Please let me know if there are some contribution guidelines or anything else, happy to help out!